### PR TITLE
Remove AVF_INFO content

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Here are my changes:
   - Remove `MEDIA_REGEX` as I want to avoid removing wrong files by mistake
   - Remove files from SD card when copied (using `--remove-source-files` option of rsync)
   - Backup video as well (`PRIVATE` directory)
+  - Remove files in `AVF_INFO` to reset the file indexing
 - Rename some paths and files
 
 

--- a/build/EnterRouterMode.sh
+++ b/build/EnterRouterMode.sh
@@ -149,6 +149,7 @@ if [ $sdcard -eq 1 -a $storedrive -eq 1 ];then
                         if  [ $? -eq 0 ]; then
                                 find "$SD_MOUNTPOINT"/DCIM -depth -type f -iname ".*" -exec rm {} \;
                                 find "$SD_MOUNTPOINT"/DCIM/* -depth -type d -exec rmdir {} \;
+                                find "$SD_MOUNTPOINT"/AVF_INFO/* -depth -type f -exec rm -f {} \;
                                 echo "$(date) - SD copy complete" >> "$LOG_FILE"
                         else
                                 echo "$(date) - Didn't finish moving files from incoming" >> "$LOG_FILE"

--- a/usb_backup.sh
+++ b/usb_backup.sh
@@ -102,6 +102,7 @@ if [ $sdcard -eq 1 -a $storedrive -eq 1 ];then
                         if  [ $? -eq 0 ]; then
                                 find "$SD_MOUNTPOINT"/DCIM -depth -type f -iname ".*" -exec rm {} \;
                                 find "$SD_MOUNTPOINT"/DCIM/* -depth -type d -exec rmdir {} \;
+                                find "$SD_MOUNTPOINT"/AVF_INFO/* -depth -type f -exec rm -f {} \;
                                 echo "$(date) - SD copy complete" >> "$LOG_FILE"
                         else
                                 echo "$(date) - Didn't finish moving files from incoming" >> "$LOG_FILE"


### PR DESCRIPTION
Sony uses an obscure (proprietary?) indexing system on the SD card.
Each time you empty `DCIM` folder (or folder containing video file),
a message appears on the camera indicating an error and you got
errors in playback (because it tries to access files which have been
removed).

So let's reset this index by removing these files.
The camera still indicates there is an error on indexing, but you
just have to click `OK` and the camera resets the index.
As a consequence, you don't have errors in playback anymore.